### PR TITLE
Update shopify.extension.toml

### DIFF
--- a/extensions/read-custom-data/shopify.extension.toml
+++ b/extensions/read-custom-data/shopify.extension.toml
@@ -9,6 +9,7 @@ api_version = "2025-10"
 name = "read-custom-data"
 handle = "read-custom-data"
 type = "ui_extension"
+uid = "f46fa293-fd0d-bdce-90c1-2201705aad7f4cd4a809"
 
 # Controls where in Shopify your extension will be injected,
 # and the file that contains your extension’s source code. Learn more:


### PR DESCRIPTION
Add deterministic UID based on extension handle

Relates to: https://github.com/Shopify/shopify-dev/issues/65152

Purpose:
The uid field is now required in shopify.extension.toml files for all extensions. UIDs are generated deterministically from the handle to ensure consistent values and allow users to safely copy examples without replacing placeholders.